### PR TITLE
Fix 'now()' not working on label values

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -3,109 +3,169 @@
 
 [[projects]]
   branch = "master"
+  digest = "1:a74730e052a45a3fab1d310fdef2ec17ae3d6af16228421e238320846f2aaec8"
   name = "github.com/alecthomas/template"
-  packages = [".","parse"]
+  packages = [
+    ".",
+    "parse",
+  ]
+  pruneopts = ""
   revision = "a0175ee3bccc567396460bf5acd36800cb10c49c"
 
 [[projects]]
   branch = "master"
+  digest = "1:8483994d21404c8a1d489f6be756e25bfccd3b45d65821f25695577791a08e68"
   name = "github.com/alecthomas/units"
   packages = ["."]
+  pruneopts = ""
   revision = "2efee857e7cfd4f3d0138cc3cbb1b4966962b93a"
 
 [[projects]]
   branch = "master"
+  digest = "1:c0bec5f9b98d0bc872ff5e834fac186b807b656683bd29cb82fb207a1513fabb"
   name = "github.com/beorn7/perks"
   packages = ["quantile"]
+  pruneopts = ""
   revision = "3a771d992973f24aa725d07868b467d1ddfceafb"
 
 [[projects]]
+  digest = "1:cae43c561aede92cd3943f628df2246948a569f7d3b0c5307b369d4cc16efb47"
   name = "github.com/fstab/grok_exporter"
   packages = ["tailer"]
+  pruneopts = ""
   revision = "81c0afe77cc292cf9e162321a455cfc9aee7d19a"
   version = "v0.2.6"
 
 [[projects]]
+  digest = "1:3dd078fda7500c341bc26cfbc6c6a34614f295a2457149fc1045cab767cbcf18"
   name = "github.com/golang/protobuf"
   packages = ["proto"]
+  pruneopts = ""
   revision = "aa810b61a9c79d51363740d207bb46cf8e620ed5"
   version = "v1.2.0"
 
 [[projects]]
+  digest = "1:6a874e3ddfb9db2b42bd8c85b6875407c702fa868eed20634ff489bc896ccfd3"
   name = "github.com/konsorten/go-windows-terminal-sequences"
   packages = ["."]
+  pruneopts = ""
   revision = "5c8c8bd35d3832f5d134ae1e1e375b69a4d25242"
   version = "v1.0.1"
 
 [[projects]]
+  digest = "1:63722a4b1e1717be7b98fc686e0b30d5e7f734b9e93d7dee86293b6deab7ea28"
   name = "github.com/matttproud/golang_protobuf_extensions"
   packages = ["pbutil"]
+  pruneopts = ""
   revision = "c12348ce28de40eed0136aa2b644d0ee0650e56c"
   version = "v1.0.1"
 
 [[projects]]
+  digest = "1:6f218995d6a74636cfcab45ce03005371e682b4b9bee0e5eb0ccfd83ef85364f"
   name = "github.com/prometheus/client_golang"
-  packages = ["prometheus","prometheus/internal","prometheus/promhttp"]
+  packages = [
+    "prometheus",
+    "prometheus/internal",
+    "prometheus/promhttp",
+  ]
+  pruneopts = ""
   revision = "505eaef017263e299324067d40ca2c48f6a2cf50"
   version = "v0.9.2"
 
 [[projects]]
   branch = "master"
+  digest = "1:185cf55b1f44a1bf243558901c3f06efa5c64ba62cfdcbb1bf7bbe8c3fb68561"
   name = "github.com/prometheus/client_model"
   packages = ["go"]
+  pruneopts = ""
   revision = "5c3871d89910bfb32f5fcab2aa4b9ec68e65a99f"
 
 [[projects]]
   branch = "master"
+  digest = "1:3015ace839b82abfb015b6fc2aebf32f4a6a8c522defacd916552387948c22a8"
   name = "github.com/prometheus/common"
-  packages = ["expfmt","internal/bitbucket.org/ww/goautoneg","model"]
+  packages = [
+    "expfmt",
+    "internal/bitbucket.org/ww/goautoneg",
+    "model",
+  ]
+  pruneopts = ""
   revision = "4724e9255275ce38f7179b2478abeae4e28c904f"
 
 [[projects]]
   branch = "master"
+  digest = "1:2a434946be9f2f5498b2405a8607768aab439237ea13deff2edc59d9a44f8891"
   name = "github.com/prometheus/procfs"
-  packages = [".","internal/util","nfs","xfs"]
+  packages = [
+    ".",
+    "internal/util",
+    "nfs",
+    "xfs",
+  ]
+  pruneopts = ""
   revision = "1dc9a6cbc91aacc3e8b2d63db4d2e957a5394ac4"
 
 [[projects]]
+  digest = "1:9d57e200ef5ccc4217fe0a34287308bac652435e7c6513f6263e0493d2245c56"
   name = "github.com/sirupsen/logrus"
   packages = ["."]
+  pruneopts = ""
   revision = "bcd833dfe83d3cebad139e4a29ed79cb2318bf95"
   version = "v1.2.0"
 
 [[projects]]
   branch = "master"
+  digest = "1:887074c37fcefc2f49b5ae9c6f9f36107341aec23185613d0e9f1ee81db7f94a"
   name = "golang.org/x/crypto"
   packages = ["ssh/terminal"]
+  pruneopts = ""
   revision = "505ab145d0a99da450461ae2c1a9f6cd10d1f447"
 
 [[projects]]
   branch = "master"
+  digest = "1:5d40dd0a18fbf7941aa3d49f68bae1c3256f3cb1f31e7372d9b32b88e8e1c976"
   name = "golang.org/x/exp"
   packages = ["winfsnotify"]
+  pruneopts = ""
   revision = "7d6377eee41ff45f3c44dfa30e3c2275066a5cf6"
 
 [[projects]]
   branch = "master"
+  digest = "1:c2c4c39f961dde3f317a48713db65329863b61316edabf19b96784b2da8406ac"
   name = "golang.org/x/sys"
-  packages = ["unix","windows"]
+  packages = [
+    "unix",
+    "windows",
+  ]
+  pruneopts = ""
   revision = "4d1cda033e0619309c606fc686de3adcf599539e"
 
 [[projects]]
+  digest = "1:15d017551627c8bb091bde628215b2861bed128855343fdd570c62d08871f6e1"
   name = "gopkg.in/alecthomas/kingpin.v2"
   packages = ["."]
+  pruneopts = ""
   revision = "947dcec5ba9c011838740e680966fd7087a71d0d"
   version = "v2.2.6"
 
 [[projects]]
+  digest = "1:cedccf16b71e86db87a24f8d4c70b0a855872eb967cb906a66b95de56aefbd0d"
   name = "gopkg.in/yaml.v2"
   packages = ["."]
+  pruneopts = ""
   revision = "51d6538a90f86fe93ac480b35f37b2be17fef232"
   version = "v2.2.2"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "f6a1c1e47e37877a9d3b606a4f3743377a5a65f2c4e31af960a3d1c4b0d7fef7"
+  input-imports = [
+    "github.com/fstab/grok_exporter/tailer",
+    "github.com/prometheus/client_golang/prometheus",
+    "github.com/prometheus/client_golang/prometheus/promhttp",
+    "github.com/sirupsen/logrus",
+    "gopkg.in/alecthomas/kingpin.v2",
+    "gopkg.in/yaml.v2",
+  ]
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/config.go
+++ b/config.go
@@ -137,6 +137,10 @@ func (pc *PatternConfig) eval(matches []string) (float64, error) {
 func (pc *PatternConfig) getEvaluatedLabels(matches []string) (map[string]string, error) {
 	ret := map[string]string{}
 	for label, val := range pc.Labels {
+		if val == "now()" {
+			ret[label] = strconv.FormatInt(time.Now().Unix(), 10)
+			continue
+		}
 		if !strings.HasPrefix(val, "$") {
 			ret[label] = val
 			continue

--- a/config_test.go
+++ b/config_test.go
@@ -127,7 +127,10 @@ func TestPatternEvalTime(t *testing.T) {
 	if err != nil {
 		t.Fatalf("got err: %s", err)
 	}
-	if int64(got) < time.Now().Unix() && int64(got) > time.Now().Unix()-60 {
+
+	now:=time.Now().Unix()
+
+	if !(int64(got) <= now && int64(got) > now -60) {
 		t.Fatalf("wrong value, got=%v", got)
 	}
 }

--- a/config_test.go
+++ b/config_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"strconv"
 	"testing"
 	"time"
 )
@@ -130,6 +131,37 @@ func TestPatternEvalTime(t *testing.T) {
 		t.Fatalf("wrong value, got=%v", got)
 	}
 }
+
+func TestPatternEvalLabelTime(t *testing.T) {
+	pc := &PatternConfig{
+		Metric: "last_success",
+		Type:   "gauge",
+		Action: "set",
+		Value:  "83",
+		Labels: map[string]string{
+			"timestamp": "now()",
+		},
+	}
+	err := pc.compile()
+	if err != nil {
+		t.Fatalf("compile failed: %s", err)
+	}
+	got, err := pc.getEvaluatedLabels([]string{})
+	if err != nil {
+		t.Fatalf("got err: %s", err)
+	}
+
+	now:=time.Now().Unix()
+	gotLabelTs, err := strconv.ParseInt(got["timestamp"], 10, 64)
+	if err != nil {
+		t.Fatalf("got err: %s", err)
+	}
+
+	if !(gotLabelTs <= now && gotLabelTs > now-60) {
+		t.Fatalf("wrong value, got=%v", got)
+	}
+}
+
 
 func TestPatternEvalMatch(t *testing.T) {
 	pc := &PatternConfig{


### PR DESCRIPTION
First of all, thanks for your project! While browsing for a way to generate metrics from arbitrary logs, I didn't want to go to complex/grok based solutions since my requirement was pretty simple. I thought about writing this functionality myself only to find out someone had already done so :)

According to the documentation, the function `now()` should be valid for label values:

> Supported values (for metric results and label values):
>
>  * Static numbers, such as `1`, `10.3e5`
>  * Regex group references, such as `$pool` from the regexp `pool=(?P<pool>[^ ]+) msg`
>  * `now()` which returns the current Unix time

This PR makes `now()` evaluated also for labels.

I have split the PR into 3 commits:
* The fix itself
* An amendment to the test of the `now()` usage in metric values. Please correct me if I'm wrong or misunderstood the test
* Updating of the packages through dep ensure

Feel free to drop any commit or let me know if any changes required/suggested.