### PR TITLE
Add configuration reload mechanism

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 logs/
+temp/
 *.swo
 *.swp
 multilog_exporter

--- a/README.md
+++ b/README.md
@@ -38,6 +38,22 @@ In general, the config consists of a list of log file paths.
 For each log file path, a list of patterns is configured.
 The pattern describes how to map log lines to Prometheus metrics.
 
+### Reloading configuration
+
+Configuration can be reloaded without stopping the application, by means of a `SIGHUP` signal. This can be useful to
+change the configuration (for instance, adding new log files or patterns) without losing current exposed metrics.
+
+```bash
+$ kill -SIGHUP $(pidof multilog_exporter)
+```
+
+When doing so, the application log should reflect the reload
+
+```text
+INFO[0137] SIGHUP received, reloading config file        configFile=doc/example.yaml
+INFO[0137] Loading config file                           configFile=doc/example.yaml
+```
+
 ## Limitations
 ### Multi-cardinality
 There is no support for working with multi-cardinality in log files.

--- a/config_test.go
+++ b/config_test.go
@@ -6,7 +6,8 @@ import (
 )
 
 func TestLoadExampleConfig(t *testing.T) {
-	c, err := loadConfigFile("doc/example.yaml")
+	c := Config{}
+	err := c.load("doc/example.yaml")
 	if err != nil {
 		t.Fatalf("error: %s", err)
 	}

--- a/doc/example2.yaml
+++ b/doc/example2.yaml
@@ -1,0 +1,116 @@
+# This is the entry point and specifies a list of log-specific configurations.
+# So, which files do you want to monitor...?
+logs:
+
+  # The path to a monitored log should usually be absolute, but we are using a relative path
+  # here to make this example config work on different user's machines:
+  - path: logs/kernel.log
+
+    # For each log file, one or more patterns should be specified.
+    # The pattern describes how log lines are mapped to Prometheus metrics:
+    patterns:
+
+      # A pattern starts with a `match` key, which contains a regular expression.
+      # Patterns are anchored. Therefore, typically there is no need for using ^ or $ characters.
+      - match: 'panic:.*'
+
+        # The next step is specifying the Prometheus metric name:
+        metric: kernel_panics
+
+        # ... and you also have to tell us whether this is a monotonically increasing metric
+        # (a `counter`, as seen here) or a gauge (see below):
+        type: counter
+
+        # A short help text should be provided. It is included in the Prometheus metric output.
+        help: Number of kernel panics
+
+        # The action specifies what to do when the pattern matches.
+        # In this case it is set to `inc`, which means to increment the counter.
+        action: inc
+
+        # The counter is incremented by the content of the `value` field.
+        # In this case, each match would lead to the counter being increased by one:
+        value: 1
+
+        # If this pattern matches the current line, further pattern processing is stopped.
+        # This is the default behavior (if `continue` was omitted).
+        continue: false
+
+  - path: logs/instance.log
+
+    patterns:
+      # This match pattern shows that you can make use of capturing groups:
+      - match: 'copying (?P<bytes>\d+) bytes in instance (?P<instance>[^ ]+), result'
+
+        metric: copied_bytes
+
+        type: counter
+
+        help: Amount of bytes copied
+
+        # Until now, we did not encounter a metric with labels. Now, there is one.
+        # The provided labels will be added to the output in the typical Prometheus
+        # syntax:
+        labels:
+          # Results from capturing groups can be referenced in labels using the dollar sign:
+          instance: $instance
+
+        action: inc
+
+        # Capturing group results can also be referenced in the value field:
+        value: $bytes
+
+        # In this case, we want pattern processing to continue, even if this entry matched.
+        # This can make sense when you want to count all lines which denote a request, but
+        # want to add an additional metric for all lines which (in addition) contain an
+        # error indicator:
+        continue: true
+
+      - match: 'copying (?P<bytes>\d+) bytes in instance (?P<instance>[^ ]+), result'
+        metric: copying_requests_total
+        type: counter
+        help: Number of copying requests
+        labels:
+          instance: $instance
+        action: inc
+        value: 1
+        continue: true
+
+      - match: 'copying (?P<bytes>\d+) bytes in instance (?P<instance>[^ ]+), result: error'
+        metric: copying_errors_total
+        type: counter
+        help: Number of errors in copying requests
+        labels:
+          instance: $instance
+        action: inc
+        value: 1
+
+      - match: 'users only in pool (?P<pool>[^ ]+): (?P<count>\d+)'
+        metric: users_only
+
+        # Until now we have only seen counters. Now we have a gauge. In contrast to a counter,
+        # a gauge may fluctuate arbitrarily. Its value may also decrease.
+        type: gauge
+        help: Number of users online
+        labels:
+          pool: $pool
+
+        # In contrast to a counter, a gauge can also be set explicitly, which is what we do here.
+        # This is useful if the log contains some kind of current status information:
+        action: set
+
+        value: $count
+
+      - match: 'requests per second: (?P<count>\d+)'
+        metric: requests_per_second
+
+        # Until now we have only seen counters. Now we have a gauge. In contrast to a counter,
+        # a gauge may fluctuate arbitrarily. Its value may also decrease.
+        type: gauge
+        help: Number of requests per second
+
+        # In contrast to a counter, a gauge can also be set explicitly, which is what we do here.
+        # This is useful if the log contains some kind of current status information:
+        action: set
+
+        value: $count

--- a/metrics.go
+++ b/metrics.go
@@ -7,8 +7,6 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-var metricsByName = make(map[string]prometheus.Collector)
-
 func registerMetrics(pcs []*PatternConfig) error {
 	for idx, pc := range pcs {
 		log.WithFields(log.Fields{"metric": pc.Metric}).Info("Registering pattern")

--- a/tailer_test.go
+++ b/tailer_test.go
@@ -152,3 +152,13 @@ func TestHandleLine(t *testing.T) {
 	handleLine("finishing job", patterns)
 	want("\njobs_inflight 0\n")
 }
+
+func TestRunTailer(t *testing.T) {
+	c := &Config{}
+	tailers := NewSafeTailers()
+	err := runTailer(c, "doc/example.yaml", tailers)
+	if err != nil {
+		t.Fatalf("Got error: %v, wanted: nil", err)
+	}
+
+}


### PR DESCRIPTION
This PR adds the ability to reload the configuration without stopping the application, by means of a `SIGHUP` signal. 

The use case is wanting to change the configuration without losing current exposed metrics.